### PR TITLE
Addon management

### DIFF
--- a/database/migrations/2025_01_03_000129_create_twist_addons_table.php
+++ b/database/migrations/2025_01_03_000129_create_twist_addons_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Obelaw\Twist\Base\BaseMigration;
+
+return new class extends BaseMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create($this->prefix . 'twist_addons', function (Blueprint $table) {
+            $table->string('id')->index()->unique();
+            $table->string('pointer');
+            $table->boolean('is_active')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists($this->prefix . 'twist_addons');
+    }
+};

--- a/src/Addons/AddonRegistrar.php
+++ b/src/Addons/AddonRegistrar.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Obelaw\Twist\Addons;
+
+class AddonRegistrar
+{
+    private static $paths = [];
+
+    public static function register(string $name, string $path): void
+    {
+        static::$paths[$name] = $path;
+    }
+
+    public static function getPaths(): array
+    {
+        return static::$paths;
+    }
+}

--- a/src/Addons/AddonsPool.php
+++ b/src/Addons/AddonsPool.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Obelaw\Twist\Addons;
+
+class AddonsPool
+{
+    const LEVELONE = '/*/twist.php';
+    const LEVELTWO = '/**/*/twist.php';
+
+    /**
+     * Pool paths
+     * 
+     * @var array
+     */
+    private static $poolPaths = [];
+
+    /**
+     * Set new pool path
+     *
+     * @param string $path
+     * @param string|null $level
+     */
+    public static function setPoolPath($path, $level = null): void
+    {
+        array_push(static::$poolPaths, [
+            'level' => $level ?? self::LEVELTWO,
+            'path' => $path
+        ]);
+    }
+
+    /**
+     * Check if the pool has paths
+     */
+    public static function hasPools(): bool
+    {
+        return (count(static::$poolPaths) != 0) ? true : false;
+    }
+
+    /**
+     * Scan the pool paths
+     */
+    public static function scan(): void
+    {
+        foreach (static::$poolPaths as $scan) {
+            foreach (glob($scan['path'] . $scan['level']) as $obelaw) {
+                require $obelaw;
+            }
+        }
+    }
+}

--- a/src/Classes/TwistClass.php
+++ b/src/Classes/TwistClass.php
@@ -8,8 +8,11 @@ use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Obelaw\Twist\Base\BaseAddon;
+use Obelaw\Twist\Models\Addon;
 
 class TwistClass
 {
@@ -31,6 +34,14 @@ class TwistClass
 
     public function make(): static
     {
+        $tableAddons = (new Addon)->getTable();
+
+        if (Schema::hasTable($tableAddons)) {
+            $this->addons = array_map(function ($pointer) {
+                return (new $pointer)->make();
+            }, DB::table($tableAddons)->where('is_active', true)->pluck('pointer')->toArray());
+        }
+
         return $this;
     }
 

--- a/src/Console/SetupAddonCommand.php
+++ b/src/Console/SetupAddonCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Obelaw\Twist\Console;
+
+use Illuminate\Console\Command;
+use Obelaw\Twist\Models\Addon;
+
+final class SetupAddonCommand extends Command
+{
+    protected $signature = 'twist:setup:addon {id} {pointer}';
+
+    protected $description = 'Twist setup a new addon';
+
+    public function handle(): void
+    {
+        Addon::updateOrCreate([
+            'id' => $this->argument('id'),
+        ], [
+            'id' => $this->argument('id'),
+            'pointer' => $this->argument('pointer'),
+        ]);
+
+        $this->info('Addon setup completed');
+    }
+}

--- a/src/Console/SetupCommand.php
+++ b/src/Console/SetupCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Obelaw\Twist\Console;
+
+use Illuminate\Console\Command;
+use Obelaw\Twist\Addons\AddonRegistrar;
+use Obelaw\Twist\Addons\AddonsPool;
+use Obelaw\Twist\Models\Addon;
+
+final class SetupCommand extends Command
+{
+    protected $signature = 'twist:setup';
+
+    protected $description = 'Twist setup';
+
+    public function handle(): void
+    {
+        if (AddonsPool::hasPools()) {
+            AddonsPool::scan();
+
+            foreach (AddonRegistrar::getPaths() as $id => $pointer) {
+                Addon::updateOrCreate([
+                    'id' => $id,
+                ], [
+                    'id' => $id,
+                    'pointer' => $pointer,
+                ]);
+            }
+
+            $this->info('Twist setup completed');
+        } else {
+            $this->error('No addons path found');
+        }
+    }
+}

--- a/src/Console/SetupDisableCommand.php
+++ b/src/Console/SetupDisableCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Obelaw\Twist\Console;
+
+use Illuminate\Console\Command;
+use Obelaw\Twist\Models\Addon;
+
+final class SetupDisableCommand extends Command
+{
+    protected $signature = 'twist:setup:disable {addon}';
+
+    protected $description = 'Twist setup';
+
+    public function handle(): void
+    {
+        $addon = Addon::where('id', $this->argument('addon'))->first();
+
+        if ($addon) {
+            $addon->update([
+                'is_active' => false,
+            ]);
+        }
+    }
+}

--- a/src/Console/SetupDisableCommand.php
+++ b/src/Console/SetupDisableCommand.php
@@ -21,6 +21,10 @@ final class SetupDisableCommand extends Command
             $addon->update([
                 'is_active' => false,
             ]);
+
+            $this->info('Addon disabled');
+        } else {
+            $this->error('Addon not found');
         }
     }
 }

--- a/src/Console/SetupEnableCommand.php
+++ b/src/Console/SetupEnableCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Obelaw\Twist\Console;
+
+use Illuminate\Console\Command;
+use Obelaw\Twist\Models\Addon;
+
+final class SetupEnableCommand extends Command
+{
+    protected $signature = 'twist:setup:enable {addon}';
+
+    protected $description = 'Twist setup';
+
+    public function handle(): void
+    {
+        $addon = Addon::where('id', $this->argument('addon'))->first();
+
+        if ($addon) {
+            $addon->update([
+                'is_active' => true,
+            ]);
+
+            $this->info('Addon enabled');
+        } else {
+            $this->error('Addon not found');
+        }
+    }
+}

--- a/src/Models/Addon.php
+++ b/src/Models/Addon.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Obelaw\Twist\Models;
+
+
+use Obelaw\Twist\Base\BaseModel;
+
+class Addon extends BaseModel
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string|null
+     */
+    protected $table = 'twist_addons';
+
+    /**
+     * The primary key for the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * The "type" of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'pointer',
+        'is_active',
+    ];
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+}

--- a/src/TwistServiceProvider.php
+++ b/src/TwistServiceProvider.php
@@ -8,6 +8,7 @@ use Obelaw\Twist\Console\MigrateCommand;
 use Obelaw\Twist\Console\SetupAddonCommand;
 use Obelaw\Twist\Console\SetupCommand;
 use Obelaw\Twist\Console\SetupDisableCommand;
+use Obelaw\Twist\Console\SetupEnableCommand;
 
 class TwistServiceProvider extends ServiceProvider
 {
@@ -37,6 +38,7 @@ class TwistServiceProvider extends ServiceProvider
         $this->commands([
             SetupCommand::class,
             SetupAddonCommand::class,
+            SetupEnableCommand::class,
             SetupDisableCommand::class,
             MigrateCommand::class,
         ]);

--- a/src/TwistServiceProvider.php
+++ b/src/TwistServiceProvider.php
@@ -5,6 +5,7 @@ namespace Obelaw\Twist;
 use Illuminate\Support\ServiceProvider;
 use Obelaw\Twist\Classes\TwistClass;
 use Obelaw\Twist\Console\MigrateCommand;
+use Obelaw\Twist\Console\SetupCommand;
 
 class TwistServiceProvider extends ServiceProvider
 {
@@ -27,7 +28,12 @@ class TwistServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__ . '/../resources', 'obelaw-twist');
 
+        if ($this->app->runningInConsole()) {
+            $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+        }
+
         $this->commands([
+            SetupCommand::class,
             MigrateCommand::class,
         ]);
     }

--- a/src/TwistServiceProvider.php
+++ b/src/TwistServiceProvider.php
@@ -7,6 +7,7 @@ use Obelaw\Twist\Classes\TwistClass;
 use Obelaw\Twist\Console\MigrateCommand;
 use Obelaw\Twist\Console\SetupAddonCommand;
 use Obelaw\Twist\Console\SetupCommand;
+use Obelaw\Twist\Console\SetupDisableCommand;
 
 class TwistServiceProvider extends ServiceProvider
 {
@@ -36,6 +37,7 @@ class TwistServiceProvider extends ServiceProvider
         $this->commands([
             SetupCommand::class,
             SetupAddonCommand::class,
+            SetupDisableCommand::class,
             MigrateCommand::class,
         ]);
     }

--- a/src/TwistServiceProvider.php
+++ b/src/TwistServiceProvider.php
@@ -5,6 +5,7 @@ namespace Obelaw\Twist;
 use Illuminate\Support\ServiceProvider;
 use Obelaw\Twist\Classes\TwistClass;
 use Obelaw\Twist\Console\MigrateCommand;
+use Obelaw\Twist\Console\SetupAddonCommand;
 use Obelaw\Twist\Console\SetupCommand;
 
 class TwistServiceProvider extends ServiceProvider
@@ -34,6 +35,7 @@ class TwistServiceProvider extends ServiceProvider
 
         $this->commands([
             SetupCommand::class,
+            SetupAddonCommand::class,
             MigrateCommand::class,
         ]);
     }


### PR DESCRIPTION
You can add a pool at boot in any `Service Provider`
```php
use Obelaw\Twist\Addons\AddonsPool;

AddonsPool::setPoolPath(__DIR__ . '/Addons', AddonsPool::LEVELONE);
```

Create `twist.php` file
```php
use Obelaw\ERP\Addons\Accounting\AccountingAddon;

\Obelaw\Twist\Addons\AddonRegistrar::register(
    'obelaw.erp.accounting',
    AccountingAddon::class
);
```

Setup
```bash
php artisan twist:setup
```